### PR TITLE
Fix renewal deals failing due to missing service_package field

### DIFF
--- a/src/adviser_allocation/api/webhooks.py
+++ b/src/adviser_allocation/api/webhooks.py
@@ -104,6 +104,18 @@ def format_agreement_start(agreement_value):
         return ""
 
 
+def _resolve_field(fields: dict, primary: str, fallback: str, default: str = "") -> str:
+    """Return first non-blank value from primary or fallback field."""
+    value = (fields.get(primary) or "").strip()
+    if value:
+        return value
+    fb = (fields.get(fallback) or "").strip()
+    if fb:
+        logger.info("Field '%s' blank, using fallback '%s' = '%s'", primary, fallback, fb)
+        return fb
+    return default
+
+
 def _hubspot_headers() -> dict:
     """Return HubSpot API headers, raising if token not configured."""
     if not HUBSPOT_HEADERS.get("Authorization"):
@@ -134,19 +146,46 @@ def handle_allocation():
         )
 
         if event.get("object", {}).get("objectType", ""):
-            service_package = event["fields"]["service_package"]
-            household_type = event["fields"].get("household_type", "")
-            agreement_start_date = event.get("fields", {}).get("agreement_start_date", "")
+            fields = event.get("fields", {})
+            service_package = _resolve_field(fields, "service_package", "renewal_service_package")
+            household_type = _resolve_field(fields, "household_type", "renewal_household_type")
+            agreement_start_date = (fields.get("agreement_start_date") or "").strip()
+
+            if not service_package:
+                deal_id = fields.get("hs_deal_record_id", "")
+                logger.warning(
+                    "No service_package or renewal_service_package for deal %s",
+                    deal_id,
+                )
+                store_allocation_record(
+                    None,
+                    {
+                        "client_email": fields.get("client_email", ""),
+                        "deal_id": deal_id,
+                        "service_package": "",
+                        "household_type": household_type,
+                        "agreement_start_date": agreement_start_date,
+                        "status": "failed",
+                        "error_message": (
+                            "Missing service_package and renewal_service_package"
+                            " in webhook payload"
+                        ),
+                    },
+                    source="hubspot_webhook",
+                    raw_request=event,
+                )
+                return jsonify({"message": "Missing service package field"}), 200
+
             selected_user, candidate_list = get_adviser(
                 service_package, agreement_start_date, household_type
             )
             if not selected_user:
-                deal_id = event.get("fields", {}).get("hs_deal_record_id", "")
+                deal_id = fields.get("hs_deal_record_id", "")
                 logger.warning("No eligible adviser found for deal %s", deal_id)
                 store_allocation_record(
                     None,
                     {
-                        "client_email": event.get("fields", {}).get("client_email", ""),
+                        "client_email": fields.get("client_email", ""),
                         "deal_id": deal_id,
                         "service_package": service_package,
                         "household_type": household_type,
@@ -162,7 +201,7 @@ def handle_allocation():
             user = selected_user
             chosen_email = (user.get("properties") or {}).get("hs_email")
             hubspot_owner_id = user["properties"]["hubspot_owner_id"]
-            deal_id = event.get("fields", {}).get("hs_deal_record_id", "")
+            deal_id = fields.get("hs_deal_record_id", "")
             logger.info(
                 "Assigning deal %s to %s (%s)",
                 deal_id,
@@ -204,7 +243,7 @@ def handle_allocation():
                 store_allocation_record(
                     None,
                     {
-                        "client_email": event.get("fields", {}).get("client_email", ""),
+                        "client_email": fields.get("client_email", ""),
                         "adviser_email": chosen_email,
                         "adviser_name": adviser_name,
                         "adviser_hubspot_id": hubspot_owner_id,
@@ -294,7 +333,7 @@ def handle_allocation():
                 store_allocation_record(
                     None,
                     {
-                        "client_email": event.get("fields", {}).get("client_email", ""),
+                        "client_email": fields.get("client_email", ""),
                         "adviser_email": chosen_email,
                         "adviser_name": adviser_name,
                         "adviser_hubspot_id": hubspot_owner_id,
@@ -325,7 +364,7 @@ def handle_allocation():
                 store_allocation_record(
                     None,
                     {
-                        "client_email": event.get("fields", {}).get("client_email", ""),
+                        "client_email": fields.get("client_email", ""),
                         "adviser_email": chosen_email if chosen_email else "",
                         "adviser_name": adviser_name if "adviser_name" in locals() else "",
                         "adviser_hubspot_id": (

--- a/tests/test_webhook_allocation.py
+++ b/tests/test_webhook_allocation.py
@@ -30,17 +30,28 @@ def _make_allocation_payload(
     deal_id="deal-123",
     client_email="client@example.com",
     agreement_start_date="",
+    renewal_service_package=None,
+    renewal_household_type=None,
+    omit_service_package=False,
+    omit_household_type=False,
 ):
     """Build a realistic HubSpot workflow webhook payload."""
+    fields = {
+        "hs_deal_record_id": deal_id,
+        "client_email": client_email,
+        "agreement_start_date": agreement_start_date,
+    }
+    if not omit_service_package:
+        fields["service_package"] = service_package
+    if not omit_household_type:
+        fields["household_type"] = household_type
+    if renewal_service_package is not None:
+        fields["renewal_service_package"] = renewal_service_package
+    if renewal_household_type is not None:
+        fields["renewal_household_type"] = renewal_household_type
     return {
         "object": {"objectType": "DEAL", "objectId": deal_id},
-        "fields": {
-            "service_package": service_package,
-            "household_type": household_type,
-            "hs_deal_record_id": deal_id,
-            "client_email": client_email,
-            "agreement_start_date": agreement_start_date,
-        },
+        "fields": fields,
     }
 
 
@@ -400,6 +411,101 @@ class TestWebhookAllocationHubSpotFailure(unittest.TestCase):
         self.assertEqual(record["deal_id"], "deal-ERR")
         self.assertEqual(record["status"], "failed")
         self.assertIn("Network timeout", record["error_message"])
+
+
+class TestWebhookAllocationRenewals(unittest.TestCase):
+    """Renewal deals send renewal_service_package instead of service_package."""
+
+    def setUp(self):
+        self.app = app
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+
+        self.p_secret = patch(
+            "adviser_allocation.utils.auth.get_secret",
+            return_value=TEST_HUBSPOT_SECRET,
+        )
+        self.p_get_adviser = patch("adviser_allocation.api.webhooks.get_adviser")
+        self.p_patch = patch("adviser_allocation.api.webhooks.patch_with_retries")
+        self.p_store = patch("adviser_allocation.api.webhooks.store_allocation_record")
+        self.p_chat = patch("adviser_allocation.api.webhooks.send_chat_alert")
+        self.p_headers = patch(
+            "adviser_allocation.api.webhooks._hubspot_headers",
+            return_value={
+                "Authorization": "Bearer test-token",
+                "Content-Type": "application/json",
+            },
+        )
+
+        self.mock_secret = self.p_secret.start()
+        self.mock_get_adviser = self.p_get_adviser.start()
+        self.mock_patch_hs = self.p_patch.start()
+        self.mock_store = self.p_store.start()
+        self.mock_chat = self.p_chat.start()
+        self.mock_headers = self.p_headers.start()
+
+        self.mock_get_adviser.return_value = (
+            _make_adviser_user(),
+            _make_candidates_summary(),
+        )
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.raise_for_status = MagicMock()
+        self.mock_patch_hs.return_value = mock_resp
+
+    def tearDown(self):
+        self.p_secret.stop()
+        self.p_get_adviser.stop()
+        self.p_patch.stop()
+        self.p_store.stop()
+        self.p_chat.stop()
+        self.p_headers.stop()
+
+    def test_renewal_service_package_fallback(self):
+        """When service_package missing, falls back to renewal_service_package."""
+        payload = _make_allocation_payload(
+            omit_service_package=True,
+            renewal_service_package="series a",
+        )
+        response = _post_with_sig(self.client, payload)
+        self.assertEqual(response.status_code, 200)
+        self.mock_get_adviser.assert_called_once()
+        call_args = self.mock_get_adviser.call_args[0]
+        self.assertEqual(call_args[0], "series a")
+
+    def test_renewal_household_type_fallback(self):
+        """When household_type blank, falls back to renewal_household_type."""
+        payload = _make_allocation_payload(
+            household_type="",
+            renewal_household_type="couple",
+        )
+        response = _post_with_sig(self.client, payload)
+        self.assertEqual(response.status_code, 200)
+        self.mock_get_adviser.assert_called_once()
+        call_args = self.mock_get_adviser.call_args[0]
+        self.assertEqual(call_args[2], "couple")
+
+    def test_primary_field_takes_precedence(self):
+        """When both fields present, primary service_package wins."""
+        payload = _make_allocation_payload(
+            service_package="series a",
+            renewal_service_package="ipo",
+        )
+        response = _post_with_sig(self.client, payload)
+        self.assertEqual(response.status_code, 200)
+        call_args = self.mock_get_adviser.call_args[0]
+        self.assertEqual(call_args[0], "series a")
+
+    def test_missing_both_service_package_fields_stores_failed_record(self):
+        """Neither service_package nor renewal_service_package -> failed record."""
+        payload = _make_allocation_payload(omit_service_package=True)
+        response = _post_with_sig(self.client, payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["message"], "Missing service package field")
+        self.mock_get_adviser.assert_not_called()
+        self.mock_store.assert_called_once()
+        record = self.mock_store.call_args[0][1]
+        self.assertEqual(record["status"], "failed")
+        self.assertIn("Missing service_package", record["error_message"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- HubSpot renewal deals send `renewal_service_package` instead of `service_package`, causing a `KeyError` in the webhook handler and a silent 500 error
- Added `_resolve_field()` helper that falls back from `service_package` → `renewal_service_package` (and `household_type` → `renewal_household_type`)
- When both fields are missing, stores a failed allocation record with a clear error message instead of returning a silent 500

## Test plan
- [x] All 21 webhook tests pass (4 new renewal-specific tests)
- [x] Ruff lint and format clean
- [ ] Deploy and verify renewal deal webhooks allocate correctly
- [ ] Check allocation history dashboard shows proper records for renewal deals