### PR TITLE
Fix stale leave records not cleaned up during sync

### DIFF
--- a/src/adviser_allocation/db/repository.py
+++ b/src/adviser_allocation/db/repository.py
@@ -209,6 +209,34 @@ class AdviserAllocationDB:
                 },
             )
 
+    def delete_stale_future_leave(self, synced_ids: List[str], cutoff_date) -> int:
+        """Delete future leave records not in the latest sync.
+
+        Removes leave requests with start_date >= cutoff_date whose
+        leave_request_id is not in synced_ids. Returns count deleted.
+        """
+        if not synced_ids:
+            # No synced records — delete all future leave
+            with self.engine.begin() as conn:
+                result = conn.execute(
+                    text("""
+                        DELETE FROM aa_leave_requests
+                        WHERE start_date >= :cutoff_date
+                    """),
+                    {"cutoff_date": cutoff_date},
+                )
+                return result.rowcount
+        with self.engine.begin() as conn:
+            result = conn.execute(
+                text("""
+                    DELETE FROM aa_leave_requests
+                    WHERE start_date >= :cutoff_date
+                      AND leave_request_id != ALL(:synced_ids)
+                """),
+                {"cutoff_date": cutoff_date, "synced_ids": synced_ids},
+            )
+            return result.rowcount
+
     # =========================================================================
     # OFFICE CLOSURES
     # =========================================================================

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -525,6 +525,12 @@ def get_leave_requests():
         page += 1
         total_pages = e.json()["data"]["total_pages"]
 
+    # Remove stale leave records (cancelled/moved in EH but still in CloudSQL)
+    synced_ids = [lr["leave_request_id"] for lr in leave_requests]
+    deleted = cloudsql_db.delete_stale_future_leave(synced_ids, now_date)
+    if deleted:
+        logger.info("Deleted %d stale future leave records", deleted)
+
     return (leave_requests, e.status_code, {"Content-Type": "application/json"})
 
 


### PR DESCRIPTION
## Summary
- The EH leave sync only upserted approved future leave but never removed cancelled/moved records from CloudSQL
- When Ian Bell's leave was moved in Employment Hero (from July 6 to June 22 week), the old record stayed in the DB with wrong dates
- After upserting all synced records, now deletes any future-dated leave whose `leave_request_id` was not in the latest sync batch
- Added `delete_stale_future_leave()` repository method

## Test plan
- [x] All 31 existing tests pass
- [x] Ruff lint and format clean
- [ ] Deploy and trigger a manual leave sync via `/admin/sync/leave_requests`
- [ ] Verify Ian Bell's leave data reflects the correct dates from Employment Hero
- [ ] Check Cloud Run logs for "Deleted N stale future leave records" message