### PR TITLE
Fix leave + closure days should sum, not max

### DIFF
--- a/src/adviser_allocation/core/allocation.py
+++ b/src/adviser_allocation/core/allocation.py
@@ -547,7 +547,7 @@ def get_merged_schedule(user):
         return 0
 
     def combine_classification(a: str, b: str) -> str:
-        days = max(classification_days(a), classification_days(b))
+        days = min(5, classification_days(a) + classification_days(b))
         if days >= 5:
             return "Full"
         if days > 0:

--- a/tests/test_allocation_logic.py
+++ b/tests/test_allocation_logic.py
@@ -120,8 +120,8 @@ class AllocationLogicTests(unittest.TestCase):
         self.assertIn(base_week, merged)
         self.assertEqual(
             merged[base_week][2],
-            "Partial: 4",
-            "Merged schedule should keep the highest partial-day count for the week",
+            "Full",
+            "Merged schedule should sum partial days (1+4=5 → Full)",
         )
 
 


### PR DESCRIPTION
## Summary
- `combine_classification()` used `max()` to merge leave days and office closure days
- This meant 4 days annual leave + 1 day wellness closure = "Partial: 4" instead of "Full"
- Changed to `min(5, a + b)` so overlapping leave and closures correctly mark the week as fully unavailable
- Example: Ian Bell has 4 days annual leave + 1 wellness day in the same week — was showing as available for a clarify, now correctly marked as Full

## Test plan
- [x] All 5 allocation logic tests pass (updated assertion for sum behavior)
- [x] Ruff lint clean
- [ ] Deploy and verify availability chart shows correct leave classifications
- [ ] Verify Ian Bell's week with 4 days leave + wellness day shows as "Full"