### PR TITLE
Fix box folder creation contact name fallback

### DIFF
--- a/src/adviser_allocation/api/box_routes.py
+++ b/src/adviser_allocation/api/box_routes.py
@@ -1739,20 +1739,11 @@ def box_folder_create_only():
     primary_first = (primary_props.get("firstname") or "").strip()
     primary_last = (primary_props.get("lastname") or "").strip()
     if not (primary_first and primary_last):
-        logger.error(
-            "Create folder request for deal %s missing primary contact names; provided fields=%s",
+        logger.info(
+            "No contact names in payload for deal %s; will fetch from HubSpot API",
             deal_id,
-            sorted(metadata_payload.keys()),
         )
-        return (
-            jsonify(
-                {
-                    "message": "Primary contact first and last name are required",
-                    "missing": ["hs_contact_firstname", "hs_contact_lastname"],
-                }
-            ),
-            400,
-        )
+        contacts_hint = []
 
     salutation = (metadata_payload.get("deal_salutation") or "").strip()
     if not salutation:
@@ -1777,7 +1768,7 @@ def box_folder_create_only():
     try:
         result = provision_box_folder(
             deal_id,
-            contacts_override=contacts_hint,
+            contacts_override=contacts_hint or None,
             folder_name_override=folder_name_override,
         )
     except BoxAutomationError as exc:


### PR DESCRIPTION
## Summary
- Remove strict 400 validation requiring contact names in the box folder creation payload
- When names are missing, fall back to fetching contacts from HubSpot API via `get_hubspot_deal_contacts()`
- Restores the original App Engine behavior that was broken during the Cloud Run migration

## Context
The HubSpot workflow only sends `deal_salutation` — it doesn't include `hs_contact_firstname`/`hs_contact_lastname`. The App Engine version worked because `provision_box_folder` fell through to the HubSpot API lookup. A strict validation was added during migration that blocked this fallback path.

## Test plan
- [ ] Re-enroll a deal and verify folder creation succeeds without contact names in the payload
- [ ] Verify folder name is correctly built from HubSpot contact data