### PR TITLE
Add error handling and alerting to Box folder automation

### DIFF
--- a/src/adviser_allocation/api/box_routes.py
+++ b/src/adviser_allocation/api/box_routes.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from flask import Blueprint, jsonify, redirect, render_template, request, session
 
+from adviser_allocation.api.webhooks import build_chat_card_payload, send_chat_alert
 from adviser_allocation.services import box_folder_service as box_service
 from adviser_allocation.services.box_folder_service import (
     CLIENT_SHARING_ROLE,
@@ -54,6 +55,28 @@ REQUIRED_METADATA_FIELDS = (
 )
 
 box_bp = Blueprint("box_api", __name__)
+
+
+def _alert_box_failure(endpoint: str, deal_id: str, error: str, status_code: int) -> None:
+    """Send a Google Chat alert when a Box automation step fails."""
+    try:
+        payload = build_chat_card_payload(
+            f"Box Automation Failure ({status_code})",
+            [
+                {
+                    "header": "Details",
+                    "lines": [
+                        f"<b>Endpoint:</b> {endpoint}",
+                        f"<b>Deal ID:</b> {deal_id or 'unknown'}",
+                        f"<b>Status:</b> {status_code}",
+                        f"<b>Error:</b> {error[:300]}",
+                    ],
+                },
+            ],
+        )
+        send_chat_alert(payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to send Box failure chat alert: %s", exc)
 
 
 @lru_cache(maxsize=1)
@@ -1758,6 +1781,11 @@ def box_folder_create_only():
             400,
         )
 
+    service = ensure_box_service()
+    if not service:
+        _alert_box_failure("/box/folder/create", deal_id, "Box automation not configured", 503)
+        return jsonify({"message": "Box automation not configured"}), 503
+
     logger.info(
         "Create-only Box folder request for deal %s (override=%s, metadata_fields=%s)",
         deal_id,
@@ -1773,6 +1801,7 @@ def box_folder_create_only():
         )
     except BoxAutomationError as exc:
         logger.error("Box folder creation failed for deal %s: %s", deal_id, exc)
+        _alert_box_failure("/box/folder/create", deal_id, str(exc), 502)
         return (
             jsonify(
                 {
@@ -1785,6 +1814,7 @@ def box_folder_create_only():
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Unexpected error during Box folder creation for deal %s", deal_id)
+        _alert_box_failure("/box/folder/create", deal_id, str(exc), 500)
         return (
             jsonify(
                 {
@@ -1875,17 +1905,20 @@ def box_folder_apply_metadata():
 
     service = ensure_box_service()
     if not service:
+        _alert_box_failure("/box/folder/tag", deal_id, "Box automation not configured", 503)
         return jsonify({"message": "Box automation not configured"}), 503
 
     try:
         service.apply_metadata_template(folder_id, metadata)
     except BoxAutomationError as exc:
         logger.error("Metadata apply failed for folder %s deal %s: %s", folder_id, deal_id, exc)
+        _alert_box_failure("/box/folder/tag", deal_id, str(exc), 502)
         return jsonify({"message": "Box metadata apply failed", "error": str(exc)}), 502
     except Exception as exc:  # noqa: BLE001
         logger.exception(
             "Unexpected error during metadata apply for folder %s deal %s", folder_id, deal_id
         )
+        _alert_box_failure("/box/folder/tag", deal_id, str(exc), 500)
         return jsonify(
             {"message": "Unexpected server error during metadata apply", "error": str(exc)}
         ), 500
@@ -1971,6 +2004,7 @@ def box_folder_apply_metadata_auto():
 
     service = ensure_box_service()
     if not service:
+        _alert_box_failure("/box/folder/tag/auto", deal_id, "Box automation not configured", 503)
         return jsonify({"message": "Box automation not configured"}), 503
 
     try:
@@ -1979,11 +2013,13 @@ def box_folder_apply_metadata_auto():
         logger.error(
             "Auto metadata apply failed for folder %s deal %s: %s", folder_id, deal_id, exc
         )
+        _alert_box_failure("/box/folder/tag/auto", deal_id, str(exc), 502)
         return jsonify({"message": "Box metadata apply failed", "error": str(exc)}), 502
     except Exception as exc:  # noqa: BLE001
         logger.exception(
             "Unexpected error during auto metadata apply for folder %s deal %s", folder_id, deal_id
         )
+        _alert_box_failure("/box/folder/tag/auto", deal_id, str(exc), 500)
         return jsonify(
             {"message": "Unexpected server error during metadata apply", "error": str(exc)}
         ), 500

--- a/src/adviser_allocation/services/box_folder_service.py
+++ b/src/adviser_allocation/services/box_folder_service.py
@@ -10,6 +10,7 @@ import requests
 from boxsdk import Client, JWTAuth
 from boxsdk.exception import BoxAPIException
 
+from adviser_allocation.utils.http_client import create_session_with_retries
 from adviser_allocation.utils.secrets import get_secret
 
 DEFAULT_BOX_API_BASE_URL = "https://api.box.com/2.0"
@@ -85,8 +86,9 @@ class BoxFolderService:
 
         template_id = self._resolve_path(self._template_path)
         payload = {"name": sanitized, "parent": {"id": parent_id}}
+        session = create_session_with_retries(retries=3)
         try:
-            resp = requests.post(
+            resp = session.post(
                 f"{self._api_base_url}/folders/{template_id}/copy",
                 headers=self._headers("application/json"),
                 json=payload,
@@ -94,6 +96,8 @@ class BoxFolderService:
             )
         except requests.RequestException as exc:
             raise BoxAutomationError(f"Box folder copy failed: {exc}") from exc
+        finally:
+            session.close()
 
         if resp.status_code == 409:
             try:
@@ -556,11 +560,10 @@ class BoxFolderService:
     def apply_metadata_template(self, folder_id: str, metadata: dict) -> None:
         """Apply configured metadata template to folder."""
         if not self._metadata_scope or not self._metadata_template_key:
-            logger.debug(
-                "Box metadata template not configured; skipping metadata apply for folder %s",
-                folder_id,
+            raise BoxAutomationError(
+                f"Box metadata template not configured (scope={self._metadata_scope!r}, "
+                f"key={self._metadata_template_key!r}); cannot apply metadata to folder {folder_id}"
             )
-            return
 
         raw_metadata = metadata or {}
         prepared: dict[str, str] = {}
@@ -596,13 +599,14 @@ class BoxFolderService:
             removals,
         )
 
+        session = create_session_with_retries(retries=3)
         try:
-            resp = requests.post(url, headers=headers, json=prepared, timeout=self._timeout)
+            resp = session.post(url, headers=headers, json=prepared, timeout=self._timeout)
             if resp.status_code == 409:
                 # Metadata already exists; fetch current values to build patch operations
                 existing: dict[str, str] = {}
                 try:
-                    existing_resp = requests.get(
+                    existing_resp = session.get(
                         url, headers=self._headers(), timeout=self._timeout
                     )
                     if existing_resp.ok:
@@ -633,7 +637,7 @@ class BoxFolderService:
                     )
                     return
 
-                resp = requests.put(
+                resp = session.put(
                     url,
                     headers=patch_headers,
                     data=json.dumps(operations),
@@ -650,6 +654,8 @@ class BoxFolderService:
             raise BoxAutomationError(
                 f"Box metadata apply failed for folder {folder_id}: {exc}"
             ) from exc
+        finally:
+            session.close()
 
     def rename_metadata_template(self, display_name: str) -> dict:
         """Rename the configured metadata template display name."""

--- a/src/adviser_allocation/services/box_folder_service.py
+++ b/src/adviser_allocation/services/box_folder_service.py
@@ -606,9 +606,7 @@ class BoxFolderService:
                 # Metadata already exists; fetch current values to build patch operations
                 existing: dict[str, str] = {}
                 try:
-                    existing_resp = session.get(
-                        url, headers=self._headers(), timeout=self._timeout
-                    )
+                    existing_resp = session.get(url, headers=self._headers(), timeout=self._timeout)
                     if existing_resp.ok:
                         existing = {
                             key: value


### PR DESCRIPTION
## Summary
- Raise `BoxAutomationError` when `BOX_METADATA_SCOPE`/`BOX_METADATA_TEMPLATE_KEY` not configured instead of silently skipping metadata
- Add explicit `ensure_box_service()` check to `/box/folder/create` (was missing, unlike `/tag` and `/tag/auto`)
- Send Google Chat alerts on all Box automation failures (502/500/503) across all 3 endpoints
- Use retry sessions (3 retries with exponential backoff) for Box API calls in `ensure_client_folder` and `apply_metadata_template`

## Context
Recent deal automation failures went unnoticed because: (1) missing env vars caused silent skips, (2) no alerting was configured for Box failures, (3) transient API failures had no retry logic.

## Test plan
- [ ] CI passes (tests + lint)
- [ ] Deploy and verify new revision starts with Box routes registered
- [ ] Confirm existing deal workflow still creates folders and applies metadata