### PR TITLE
Remove App Engine migration artifacts

### DIFF
--- a/.claude/commands/SKILL.md
+++ b/.claude/commands/SKILL.md
@@ -28,10 +28,4 @@ mypy src/
 
 ## Deployment Note
 
-This repo uses App Engine. After passing tests:
-
-```bash
-gcloud app deploy --project=pivot-digital-466902
-```
-
-CI/CD auto-deploys on push to main if tests pass.
+This repo deploys to Cloud Run. CI/CD auto-deploys on push to main if tests pass.

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -2294,7 +2294,6 @@ def create_app(config_overrides=None):
             "PERMANENT_SESSION_LIFETIME": 3600,
             "PREFERRED_URL_SCHEME": "https" if is_production else "http",
             "DEV_LOGIN_ENABLED": not is_production,
-            "SHOW_MIGRATION_BANNER": os.environ.get("GAE_ENV") == "standard",
         }
     )
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -62,13 +62,6 @@
   <button class="sidebar-toggle" id="sidebarToggle" aria-label="Toggle navigation">&#9776;</button>
   {% endif %}
   <div class="container {% if session.get('is_authenticated') %}has-sidebar{% endif %}">
-    {% if config.get('SHOW_MIGRATION_BANNER') %}
-    <div style="background:#fff3cd; border:1px solid #ffc107; border-radius:6px; padding:12px 16px; margin-bottom:16px; text-align:center;">
-      <strong>This site has moved.</strong>
-      Please update your bookmark to
-      <a href="https://adviser-allocation-307314618542.australia-southeast1.run.app{{ request.path }}{% if request.query_string %}?{{ request.query_string.decode() }}{% endif %}">the new URL</a>.
-    </div>
-    {% endif %}
     {% block content %}{% endblock %}
   </div>
   {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- Remove `SHOW_MIGRATION_BANNER` config flag and migration banner from layout template
- Update SKILL.md deployment note to reference Cloud Run instead of App Engine

## Context
App Engine has had zero workflow traffic since Apr 1. All HubSpot workflows, Cloud Scheduler jobs, and user traffic now go through Cloud Run. The proxy_routes module (App Engine → Cloud Run forwarding) was never committed to the repo.

Next step after merge: stop the App Engine serving version (`20260213t184615`) to prevent instances spinning up on bot traffic.

## Test plan
- [ ] CI passes
- [ ] Verify Cloud Run deploy works
- [ ] Stop App Engine version after deploy