### PR TITLE
Fix EH leave sync deleting valid future leave; add silent-failure detection

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -442,6 +442,53 @@ Use this in monitoring dashboards to alert if app is down.
 
 ---
 
+## Leave Sync Monitoring & Alerts
+
+The Employment Hero leave sync (`/sync/leave_requests`, daily on weekdays) has automated
+Google Chat alerts so a failing or degraded sync cannot drain leave silently. Alerts use the
+existing `CHAT_WEBHOOK_URL` webhook — no extra infra.
+
+### Alerts that fire
+
+| Alert | Trigger | What it means |
+|-------|---------|---------------|
+| **Leave sync produced no active/future leave** | A sync fetches 0 items, keeps 0 records, or leaves 0 active/future rows in the table | EH returned nothing useful (auth, API, or pagination problem). Availability data is not trustworthy until resolved. |
+| **Leave sync failed** | `/sync/leave_requests` (or the admin trigger) raised an exception | The sync errored out — token, network, or EH API failure. Check the stack trace in Cloud Run logs. |
+| **Leave sync skipped stale cleanup** | A run would have deleted > 50% of tracked active/future leave | An incomplete EH fetch was detected; the destructive delete was blocked. Investigate before the next sync. |
+
+### Health signal in logs
+
+Every successful run logs one structured summary line:
+
+```
+Leave sync: fetched N across P page(s), kept K active/future, deleted D stale, A active/future now in DB
+```
+
+`A == 0` is the red flag — it means no adviser has any current/upcoming leave recorded.
+
+### Runbook — "Advisers on leave shown as available / leave looks empty"
+
+1. Trigger a manual sync: `POST /admin/sync/leave_requests` (admin auth).
+2. Read the `Leave sync: …` log line in Cloud Run — check `fetched`, `kept`, and
+   `active/future now in DB`.
+3. Check Google Chat for the alerts above and the EH OAuth token health (`GET /sync/token-health`).
+4. Verify in CloudSQL:
+   ```sql
+   SELECT COUNT(*) FILTER (WHERE start_date <= CURRENT_DATE AND end_date >= CURRENT_DATE) AS ongoing,
+          COUNT(*) FILTER (WHERE start_date > CURRENT_DATE) AS future,
+          MAX(last_synced) AS last_synced
+   FROM aa_leave_requests;
+   ```
+   `ongoing`/`future` should be > 0 and `last_synced` recent.
+
+### Future hardening (deferred)
+
+An independent freshness heartbeat (a separate daily job that alerts if `last_synced` is stale
+or `active/future` is 0, even when the sync job stops running entirely) and a persisted
+`aa_sync_metrics` table for historical sync tracking were considered but not yet implemented.
+
+---
+
 ## Documentation
 
 - **Architecture:** [ARCHITECTURE.md](../ARCHITECTURE.md)

--- a/src/adviser_allocation/db/repository.py
+++ b/src/adviser_allocation/db/repository.py
@@ -22,6 +22,30 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+# Safety valve for stale-leave cleanup: if a single sync would prune more than this
+# fraction of the currently tracked active/future leave, treat it as an incomplete
+# fetch and skip the delete (alerting instead) rather than wiping valid records.
+STALE_DELETE_MAX_RATIO = 0.5
+
+
+def _alert_stale_delete_guard(stale_count: int, tracked_count: int) -> None:
+    """Send a Google Chat alert when the stale-leave delete guard trips."""
+    try:
+        from adviser_allocation.api.webhooks import send_chat_alert
+
+        send_chat_alert(
+            {
+                "text": (
+                    f"⚠️ Leave sync skipped stale cleanup: would have deleted "
+                    f"{stale_count} of {tracked_count} tracked active/future leave records "
+                    f"(> {STALE_DELETE_MAX_RATIO * 100:.0f}%). Likely an incomplete EH fetch — "
+                    f"investigate before the next sync."
+                )
+            }
+        )
+    except Exception as exc:
+        logger.warning("Could not send stale-delete guard alert: %s", exc)
+
 
 class AdviserAllocationDB:
     """Data access layer for adviser_allocation CloudSQL tables."""
@@ -233,32 +257,81 @@ class AdviserAllocationDB:
             )
 
     def delete_stale_future_leave(self, synced_ids: List[str], cutoff_date) -> int:
-        """Delete future leave records not in the latest sync.
+        """Prune active/future leave EH no longer reports (cancelled or moved).
 
-        Removes leave requests with start_date >= cutoff_date whose
-        leave_request_id is not in synced_ids. Returns count deleted.
+        Targets leave whose ``end_date >= cutoff_date`` (i.e. still ongoing or
+        upcoming) and whose ``leave_request_id`` is absent from ``synced_ids``.
+        Already-ended leave is left untouched as harmless history.
+
+        Two safety guards prevent a single incomplete fetch from wiping valid leave:
+          * empty ``synced_ids`` deletes nothing — a zero-result fetch is almost
+            always an upstream problem, not a mass cancellation;
+          * if the delete would remove more than ``STALE_DELETE_MAX_RATIO`` of the
+            currently tracked window, it is skipped and an alert is raised instead.
+
+        Returns the number of rows actually deleted (0 when a guard trips).
         """
         if not synced_ids:
-            # No synced records — delete all future leave
-            with self.engine.begin() as conn:
-                result = conn.execute(
-                    text("""
-                        DELETE FROM aa_leave_requests
-                        WHERE start_date >= :cutoff_date
-                    """),
-                    {"cutoff_date": cutoff_date},
-                )
-                return result.rowcount
+            logger.warning(
+                "Leave sync returned no records; skipping stale cleanup to avoid "
+                "wiping valid active/future leave."
+            )
+            return 0
+
         with self.engine.begin() as conn:
+            tracked_count = (
+                conn.execute(
+                    text("SELECT COUNT(*) FROM aa_leave_requests WHERE end_date >= :cutoff_date"),
+                    {"cutoff_date": cutoff_date},
+                ).scalar()
+                or 0
+            )
+            stale_count = (
+                conn.execute(
+                    text("""
+                        SELECT COUNT(*) FROM aa_leave_requests
+                        WHERE end_date >= :cutoff_date
+                          AND leave_request_id != ALL(:synced_ids)
+                    """),
+                    {"cutoff_date": cutoff_date, "synced_ids": synced_ids},
+                ).scalar()
+                or 0
+            )
+
+            if stale_count == 0:
+                return 0
+
+            if tracked_count > 0 and (stale_count / tracked_count) > STALE_DELETE_MAX_RATIO:
+                _alert_stale_delete_guard(stale_count, tracked_count)
+                logger.warning(
+                    "Stale leave cleanup would delete %d of %d tracked records "
+                    "(> %.0f%%); skipping and alerting — likely an incomplete EH fetch.",
+                    stale_count,
+                    tracked_count,
+                    STALE_DELETE_MAX_RATIO * 100,
+                )
+                return 0
+
             result = conn.execute(
                 text("""
                     DELETE FROM aa_leave_requests
-                    WHERE start_date >= :cutoff_date
+                    WHERE end_date >= :cutoff_date
                       AND leave_request_id != ALL(:synced_ids)
                 """),
                 {"cutoff_date": cutoff_date, "synced_ids": synced_ids},
             )
             return result.rowcount
+
+    def count_active_future_leave(self, cutoff_date) -> int:
+        """Count leave still ongoing or upcoming (end_date >= cutoff_date)."""
+        with self.engine.connect() as conn:
+            return (
+                conn.execute(
+                    text("SELECT COUNT(*) FROM aa_leave_requests WHERE end_date >= :cutoff_date"),
+                    {"cutoff_date": cutoff_date},
+                ).scalar()
+                or 0
+            )
 
     # =========================================================================
     # OFFICE CLOSURES

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -444,9 +444,45 @@ def get_employee_id():
         return {"error": "Employee not found"}, 404
 
 
+def _should_track_leave(status, end_date_obj, today) -> bool:
+    """Whether a leave request should be persisted: approved and not yet ended.
+
+    Tracking by end_date (ongoing + today + future) — rather than start_date —
+    keeps a leave for its full duration and prevents it from vanishing the day it
+    begins. Status comparison is case-insensitive to tolerate EH label drift.
+    """
+    return (status or "").lower() == "approved" and end_date_obj >= today
+
+
+def leave_sync_result_is_healthy(fetched_count, kept_count, active_future_count) -> bool:
+    """Whether a leave sync produced a plausible result.
+
+    A healthy run fetches some items from EH, keeps at least one active/future
+    record, and leaves the table with active/future leave present. Any zero here
+    matches the silent-drain failure mode and should raise an alert.
+    """
+    return fetched_count > 0 and kept_count > 0 and active_future_count > 0
+
+
+def _alert_leave_sync_problem(summary: str, details: list) -> None:
+    """Send a Google Chat alert about a leave-sync problem (degraded result or failure)."""
+    try:
+        from adviser_allocation.api.webhooks import build_chat_card_payload, send_chat_alert
+
+        send_chat_alert(
+            build_chat_card_payload(f"⚠️ {summary}", [{"header": "Leave sync", "lines": details}])
+        )
+    except Exception as exc:
+        logger.warning("Could not send leave-sync alert: %s", exc)
+
+
 @main_bp.route("/get/leave_requests")
 def get_leave_requests():
-    """Fetch future approved leave requests and persist to CloudSQL.
+    """Fetch current and upcoming approved leave requests and persist to CloudSQL.
+
+    Pulls every page of leave from Employment Hero, keeps approved leave that has
+    not yet ended (ongoing + today + future), upserts it, then prunes records EH no
+    longer reports within that window (cancelled/moved leave).
 
     Returns:
         tuple: (list of leave requests, HTTP status, headers)
@@ -456,30 +492,33 @@ def get_leave_requests():
 
     now_date = sydney_today()
 
-    page = 1
-    total_pages = 9
-
     org_id = get_org_id(headers)
     cloudsql_db = get_cloudsql_db()
 
     leave_requests = []
+    fetched_count = 0
+    page = 1
+    total_pages = 1  # Seeded; replaced with the real count from the first response.
     while page <= total_pages:
         params = {
             "item_per_page": 100,
             "page_index": page,
         }
-        e = requests.get(
+        resp = requests.get(
             f"{API_BASE}/api/v1/organisations/{org_id}/leave_requests",
             headers=headers,
             params=params,
             timeout=30,
         )
-        if e.status_code != 200:
-            raise RuntimeError(f"Refresh failed: {e.status_code} {e.text}")
+        if resp.status_code != 200:
+            raise RuntimeError(f"Leave fetch failed: {resp.status_code} {resp.text}")
 
-        for leave_request in e.json()["data"]["items"]:
-            start_date_obj = datetime.fromisoformat(leave_request["start_date"]).date()
-            if (leave_request["status"] == "Approved") and (start_date_obj > now_date):
+        payload = resp.json()["data"]
+        items = payload["items"]
+        fetched_count += len(items)
+        for leave_request in items:
+            end_date_obj = datetime.fromisoformat(leave_request["end_date"]).date()
+            if _should_track_leave(leave_request.get("status"), end_date_obj, now_date):
                 item = {
                     "leave_request_id": leave_request.get("id"),
                     "employee_id": leave_request.get("employee_id"),
@@ -490,16 +529,36 @@ def get_leave_requests():
                 leave_requests.append(item)
                 cloudsql_db.upsert_leave_request_dict(item)
 
+        total_pages = payload["total_pages"]
         page += 1
-        total_pages = e.json()["data"]["total_pages"]
 
-    # Remove stale leave records (cancelled/moved in EH but still in CloudSQL)
+    # Prune leave EH no longer reports within the active/future window. The repository
+    # applies safety guards so an incomplete fetch can never wipe valid leave.
     synced_ids = [lr["leave_request_id"] for lr in leave_requests]
     deleted = cloudsql_db.delete_stale_future_leave(synced_ids, now_date)
-    if deleted:
-        logger.info("Deleted %d stale future leave records", deleted)
+    active_future_count = cloudsql_db.count_active_future_leave(now_date)
+    logger.info(
+        "Leave sync: fetched %d across %d page(s), kept %d active/future, "
+        "deleted %d stale, %d active/future now in DB",
+        fetched_count,
+        total_pages,
+        len(leave_requests),
+        deleted,
+        active_future_count,
+    )
 
-    return (leave_requests, e.status_code, {"Content-Type": "application/json"})
+    if not leave_sync_result_is_healthy(fetched_count, len(leave_requests), active_future_count):
+        _alert_leave_sync_problem(
+            "Leave sync produced no active/future leave",
+            [
+                f"Fetched: {fetched_count}",
+                f"Kept: {len(leave_requests)}",
+                f"Active/future in DB: {active_future_count}",
+                "Likely an EH fetch/auth problem — investigate before relying on availability.",
+            ],
+        )
+
+    return (leave_requests, resp.status_code, {"Content-Type": "application/json"})
 
 
 @main_bp.route("/get/employee_leave_requests")
@@ -575,7 +634,8 @@ def sync_leave_requests():
         data, status, headers = get_leave_requests()
         return jsonify({"synced": len(data)}), status
     except Exception as e:
-        logger.error("Failed to sync leave requests: %s", e)
+        logger.exception("Failed to sync leave requests")
+        _alert_leave_sync_problem("Leave sync failed", [f"Error: {str(e)[:300]}"])
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -598,8 +658,9 @@ def admin_sync_leave_requests():
     try:
         data, status, _headers = get_leave_requests()
         return jsonify({"synced": len(data)}), status
-    except Exception:
+    except Exception as e:
         logger.exception("Admin sync leave requests failed")
+        _alert_leave_sync_problem("Leave sync failed (admin trigger)", [f"Error: {str(e)[:300]}"])
         return jsonify({"error": "Sync failed"}), 500
 
 

--- a/tests/test_leave_sync_health.py
+++ b/tests/test_leave_sync_health.py
@@ -1,0 +1,101 @@
+"""Tests for leave-sync health detection and the corrected tracking window.
+
+These lock in the prevention behaviour added after the silent leave-drain bug:
+  * `_should_track_leave` — the keep decision (approved + not yet ended), so the
+    `start_date > today` boundary regression cannot return.
+  * `leave_sync_result_is_healthy` — the zero-result signal that drives alerting.
+  * `_alert_leave_sync_problem` — fires a Google Chat alert and never raises.
+  * `count_active_future_leave` — the post-sync count feeding the health check.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from adviser_allocation.db.repository import AdviserAllocationDB
+from adviser_allocation.main import (
+    _alert_leave_sync_problem,
+    _should_track_leave,
+    leave_sync_result_is_healthy,
+)
+
+TODAY = date(2026, 6, 2)
+
+
+class TestShouldTrackLeave:
+    def test_approved_future_is_kept(self):
+        assert _should_track_leave("Approved", date(2026, 7, 28), TODAY) is True
+
+    def test_approved_ongoing_is_kept(self):
+        # Started before today, ends after today — the case that used to vanish.
+        assert _should_track_leave("Approved", date(2026, 6, 10), TODAY) is True
+
+    def test_approved_ending_today_is_kept(self):
+        assert _should_track_leave("Approved", TODAY, TODAY) is True
+
+    def test_already_ended_is_excluded(self):
+        assert _should_track_leave("Approved", date(2026, 5, 30), TODAY) is False
+
+    def test_non_approved_is_excluded(self):
+        assert _should_track_leave("Pending", date(2026, 7, 28), TODAY) is False
+
+    def test_status_is_case_insensitive(self):
+        assert _should_track_leave("APPROVED", date(2026, 7, 28), TODAY) is True
+
+    def test_missing_status_is_excluded(self):
+        assert _should_track_leave(None, date(2026, 7, 28), TODAY) is False
+
+
+class TestLeaveSyncResultIsHealthy:
+    def test_all_positive_is_healthy(self):
+        assert leave_sync_result_is_healthy(120, 30, 30) is True
+
+    def test_zero_fetched_is_unhealthy(self):
+        assert leave_sync_result_is_healthy(0, 0, 0) is False
+
+    def test_zero_kept_is_unhealthy(self):
+        assert leave_sync_result_is_healthy(120, 0, 0) is False
+
+    def test_zero_active_future_in_db_is_unhealthy(self):
+        # Fetched and kept this run, but the table ended up empty — the symptom we saw.
+        assert leave_sync_result_is_healthy(120, 5, 0) is False
+
+
+class TestAlertLeaveSyncProblem:
+    @patch("adviser_allocation.api.webhooks.send_chat_alert")
+    def test_sends_alert_with_summary(self, mock_send):
+        _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
+        mock_send.assert_called_once()
+        payload = mock_send.call_args.args[0]
+        # build_chat_card_payload wraps the summary in the card title.
+        assert "Leave sync failed" in payload["cards"][0]["header"]["title"]
+
+    @patch("adviser_allocation.api.webhooks.send_chat_alert", side_effect=RuntimeError("down"))
+    def test_swallows_alert_errors(self, _mock_send):
+        # Alerting must never break the sync.
+        _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
+
+
+class TestCountActiveFutureLeave:
+    def test_returns_scalar_count(self):
+        result = MagicMock()
+        result.scalar.return_value = 7
+        conn = MagicMock()
+        conn.execute.return_value = result
+        engine = MagicMock()
+        engine.connect.return_value.__enter__.return_value = conn
+        engine.connect.return_value.__exit__.return_value = False
+
+        db = AdviserAllocationDB(engine)
+        assert db.count_active_future_leave(TODAY) == 7
+
+    def test_none_count_coerced_to_zero(self):
+        result = MagicMock()
+        result.scalar.return_value = None
+        conn = MagicMock()
+        conn.execute.return_value = result
+        engine = MagicMock()
+        engine.connect.return_value.__enter__.return_value = conn
+        engine.connect.return_value.__exit__.return_value = False
+
+        db = AdviserAllocationDB(engine)
+        assert db.count_active_future_leave(TODAY) == 0

--- a/tests/test_repository_leave_cleanup.py
+++ b/tests/test_repository_leave_cleanup.py
@@ -1,0 +1,81 @@
+"""Tests for the stale-leave cleanup safety guards in delete_stale_future_leave.
+
+The delete query itself is Postgres-specific (``!= ALL(:array)``), so these tests
+drive the Python guard logic with a mocked engine/connection rather than a live DB.
+The guards exist because a single incomplete Employment Hero fetch previously wiped
+all active/future leave (see fix/eh-leave-sync-stale-delete).
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from adviser_allocation.db.repository import STALE_DELETE_MAX_RATIO, AdviserAllocationDB
+
+CUTOFF = date(2026, 6, 2)
+
+
+def _db_with_counts(tracked_count, stale_count, deleted_count=0):
+    """Build an AdviserAllocationDB whose mocked engine returns the given counts.
+
+    execute() is called in order: COUNT(tracked), COUNT(stale), then DELETE.
+    """
+    tracked_result = MagicMock()
+    tracked_result.scalar.return_value = tracked_count
+    stale_result = MagicMock()
+    stale_result.scalar.return_value = stale_count
+    delete_result = MagicMock()
+    delete_result.rowcount = deleted_count
+
+    conn = MagicMock()
+    conn.execute.side_effect = [tracked_result, stale_result, delete_result]
+
+    engine = MagicMock()
+    engine.begin.return_value.__enter__.return_value = conn
+    engine.begin.return_value.__exit__.return_value = False
+    return AdviserAllocationDB(engine), engine, conn
+
+
+def test_empty_synced_ids_deletes_nothing_and_skips_db():
+    """A zero-result fetch must never touch the DB — it's an upstream problem."""
+    db = AdviserAllocationDB(MagicMock())
+    deleted = db.delete_stale_future_leave([], CUTOFF)
+    assert deleted == 0
+    db.engine.begin.assert_not_called()
+
+
+def test_no_stale_records_returns_zero():
+    db, engine, conn = _db_with_counts(tracked_count=10, stale_count=0)
+    deleted = db.delete_stale_future_leave(["a", "b", "c"], CUTOFF)
+    assert deleted == 0
+    # tracked + stale counted, but no DELETE issued (only 2 execute calls).
+    assert conn.execute.call_count == 2
+
+
+def test_normal_cleanup_below_threshold_deletes():
+    db, engine, conn = _db_with_counts(tracked_count=10, stale_count=2, deleted_count=2)
+    deleted = db.delete_stale_future_leave(["x"], CUTOFF)
+    assert deleted == 2
+    # tracked + stale counts, then the DELETE.
+    assert conn.execute.call_count == 3
+
+
+@patch("adviser_allocation.db.repository._alert_stale_delete_guard")
+def test_guard_trips_above_threshold_skips_and_alerts(mock_alert):
+    """The 2026-05-20 'Deleted 24' scenario: most of the window would vanish."""
+    db, engine, conn = _db_with_counts(tracked_count=24, stale_count=20)
+    deleted = db.delete_stale_future_leave(["x"], CUTOFF)
+    assert deleted == 0
+    mock_alert.assert_called_once_with(20, 24)
+    # No DELETE executed — only the two COUNT queries ran.
+    assert conn.execute.call_count == 2
+
+
+@patch("adviser_allocation.db.repository._alert_stale_delete_guard")
+def test_exactly_at_threshold_still_deletes(mock_alert):
+    """Guard trips only when strictly above the ratio, not at it."""
+    half = int(10 * STALE_DELETE_MAX_RATIO)
+    db, engine, conn = _db_with_counts(tracked_count=10, stale_count=half, deleted_count=half)
+    deleted = db.delete_stale_future_leave(["x"], CUTOFF)
+    assert deleted == half
+    mock_alert.assert_not_called()
+    assert conn.execute.call_count == 3


### PR DESCRIPTION
## Problem

The Employment Hero leave sync was **hard-deleting legitimate active/future leave**. By 2026-06-02 `aa_leave_requests` held **0 ongoing and 0 future** records for any adviser (122 rows, all past-dated), so the allocation algorithm treated everyone as fully available. The sync endpoint returned **HTTP 200 every day**, so it went unnoticed for ~2.5 months. Concretely, Reece Dolan's Approved Annual Leave **15–28 Jul 2026** was absent from the DB.

### Root cause
`get_leave_requests` kept only `start_date > today`, but the cleanup `delete_stale_future_leave` deleted any `start_date >= today` row not in *that run's* fetch. So:
- a leave was purged the day it **began** (boundary `>` vs `>=`), and
- any record missing from a single incomplete fetch was treated as cancelled and deleted (the logs show a "Deleted 24 stale future leave records" purge on 2026-05-20).

## Fix
- Track leave by **`end_date >= today`** (ongoing + today + future), case-insensitive status — leave survives its full duration.
- Align the stale cleanup to the same `end_date` window and make it **safe**: an empty fetch deletes nothing; a run that would prune **>50%** of tracked leave is skipped and alerted instead of wiping the table.
- Seed `total_pages = 1`; log a per-run summary (`fetched/kept/deleted/active-future-in-DB`).

## Prevention (detection — reuses existing `send_chat_alert`)
- Alert when a sync **keeps 0 / fetches 0 / leaves 0** active-future records (the exact silent-drain signal).
- Alert when the sync endpoint **raises**.
- Extract `_should_track_leave` and `leave_sync_result_is_healthy` as pure, unit-tested predicates so the boundary bug cannot regress.
- New `count_active_future_leave` repository helper.
- Alerts + runbook documented in `docs/OPERATIONS.md`.

## Tests
- New `tests/test_leave_sync_health.py` + `tests/test_repository_leave_cleanup.py` (20 tests, all pass).
- Full suite: **355 passed**, coverage 49.88% (gate is 35%). The only failures are pre-existing `test_performance.py` latency thresholds (unrelated).

## Post-merge / deploy
1. Canary deploy.
2. Trigger `POST /admin/sync/leave_requests` to backfill current/future leave from EH.
3. Verify ongoing/future > 0 and Reece Dolan's 15–28 Jul 2026 leave is present.

## Rollback
Pure code change, no migration. Revert the commit; the next scheduled sync repopulates from EH (EH is the source of truth). Note: lost history is gone — only current/future leave is recoverable.