### PR TITLE
Fix EH leave pagination: page_index is 0-based

### DIFF
--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -497,9 +497,11 @@ def get_leave_requests():
 
     leave_requests = []
     fetched_count = 0
-    page = 1
+    # Employment Hero's page_index is 0-based; starting at 1 skips the first page
+    # (where leave lives when there are few pages), which is why the sync drained.
+    page = 0
     total_pages = 1  # Seeded; replaced with the real count from the first response.
-    while page <= total_pages:
+    while page < total_pages:
         params = {
             "item_per_page": 100,
             "page_index": page,
@@ -515,7 +517,15 @@ def get_leave_requests():
 
         payload = resp.json()["data"]
         items = payload["items"]
+        total_pages = payload["total_pages"]
         fetched_count += len(items)
+        logger.info(
+            "Leave fetch page_index=%d: %d items, total_pages=%d, total_count=%s",
+            page,
+            len(items),
+            total_pages,
+            payload.get("total_count"),
+        )
         for leave_request in items:
             end_date_obj = datetime.fromisoformat(leave_request["end_date"]).date()
             if _should_track_leave(leave_request.get("status"), end_date_obj, now_date):
@@ -529,7 +539,6 @@ def get_leave_requests():
                 leave_requests.append(item)
                 cloudsql_db.upsert_leave_request_dict(item)
 
-        total_pages = payload["total_pages"]
         page += 1
 
     # Prune leave EH no longer reports within the active/future window. The repository


### PR DESCRIPTION
## Problem

After #51 stopped the destructive deletes, a triggered sync revealed the **upstream** reason leave drained: the EH fetch returns **0 items, `total_pages=0`** even though leave exists in EH (e.g. Reece Dolan 15–28 Jul 2026).

Production logs from the post-#51 resync:
```
Leave sync returned no records; skipping stale cleanup ...   ← guard worked, no wipe
Leave sync: fetched 0 across 0 page(s), kept 0 ... 0 active/future now in DB
Sent chat alert successfully                                  ← alert fired
```

## Root cause
The loop started at `page_index=1`. Employment Hero's `page_index` is **0-based**, so it skipped page 0 — where leave lives when the org has only a page or two — and got an empty result. The old code had the same 1-based start, which is why leave drained from ~March.

Isolation: `/sync/employees` is healthy (88 rows, synced 2026-05-31) using the **same token + `get_org_id`** but **no pagination** — proving auth/org are fine and the bug is specific to leave's `page_index`.

## Fix
- Start pagination at `page_index=0` (`while page < total_pages`).
- Read `total_pages` before processing each page.
- Per-page diagnostic log (`items`, `total_pages`, `total_count`) to confirm the fetch on the next run.

## Verification (post-deploy)
1. Trigger `eh-leave-requests-sync-daily`.
2. Confirm log shows `page_index=0` returning items and `total_pages >= 1`.
3. Verify `aa_leave_requests` has `active/future > 0` and Reece Dolan's 15–28 Jul 2026 leave is present.

## Rollback
Pure code change, no migration. Revert; the safe-delete guard from #51 still protects the table.