### PR TITLE
Gate leave-sync Chat alerts behind LEAVE_SYNC_ALERTS_ENABLED (default off)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -456,6 +456,15 @@ existing `CHAT_WEBHOOK_URL` webhook — no extra infra.
 | **Leave sync failed** | `/sync/leave_requests` (or the admin trigger) raised an exception | The sync errored out — token, network, or EH API failure. Check the stack trace in Cloud Run logs. |
 | **Leave sync skipped stale cleanup** | A run would have deleted > 50% of tracked active/future leave | An incomplete EH fetch was detected; the destructive delete was blocked. Investigate before the next sync. |
 
+### Enabling Chat alerts
+
+Leave-sync Chat alerts are **off by default** and gated by the env var
+`LEAVE_SYNC_ALERTS_ENABLED` (set to `true`/`1`/`yes` to post to the Chat space).
+When off, every alert condition is still **logged** (`WARNING`), and the
+stale-delete guard still blocks a wipe — only the Chat post is suppressed. Leave
+this off if the webhook points at a broad space; flip it on (or repoint
+`CHAT_WEBHOOK_URL` to a dedicated ops space) when you want active notifications.
+
 ### Health signal in logs
 
 Every successful run logs one structured summary line:

--- a/src/adviser_allocation/db/repository.py
+++ b/src/adviser_allocation/db/repository.py
@@ -5,6 +5,7 @@ Encapsulates all CloudSQL queries using raw SQL with parameterized queries.
 
 import json
 import logging
+import os
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
@@ -29,7 +30,18 @@ STALE_DELETE_MAX_RATIO = 0.5
 
 
 def _alert_stale_delete_guard(stale_count: int, tracked_count: int) -> None:
-    """Send a Google Chat alert when the stale-leave delete guard trips."""
+    """Send a Google Chat alert when the stale-leave delete guard trips.
+
+    Gated by LEAVE_SYNC_ALERTS_ENABLED (default off); the guard still blocks the
+    delete regardless, this only controls whether it posts to Chat.
+    """
+    if os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "false").strip().lower() not in ("1", "true", "yes"):
+        logger.warning(
+            "Stale-delete guard alert (Chat suppressed): would delete %d of %d tracked records",
+            stale_count,
+            tracked_count,
+        )
+        return
     try:
         from adviser_allocation.api.webhooks import send_chat_alert
 

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -464,8 +464,20 @@ def leave_sync_result_is_healthy(fetched_count, kept_count, active_future_count)
     return fetched_count > 0 and kept_count > 0 and active_future_count > 0
 
 
+def _leave_sync_alerts_enabled() -> bool:
+    """Whether leave-sync Chat alerts should post. Off by default (set via env)."""
+    return os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
 def _alert_leave_sync_problem(summary: str, details: list) -> None:
-    """Send a Google Chat alert about a leave-sync problem (degraded result or failure)."""
+    """Send a Google Chat alert about a leave-sync problem (degraded result or failure).
+
+    Gated by LEAVE_SYNC_ALERTS_ENABLED (default off) so leave-sync alerts don't post
+    to the shared Chat space; the condition is always logged regardless.
+    """
+    if not _leave_sync_alerts_enabled():
+        logger.warning("Leave-sync alert (Chat suppressed): %s | %s", summary, "; ".join(details))
+        return
     try:
         from adviser_allocation.api.webhooks import build_chat_card_payload, send_chat_alert
 

--- a/tests/test_leave_sync_health.py
+++ b/tests/test_leave_sync_health.py
@@ -62,7 +62,15 @@ class TestLeaveSyncResultIsHealthy:
 
 class TestAlertLeaveSyncProblem:
     @patch("adviser_allocation.api.webhooks.send_chat_alert")
-    def test_sends_alert_with_summary(self, mock_send):
+    def test_suppressed_by_default(self, mock_send, monkeypatch):
+        # Default (flag unset) — leave-sync alerts must NOT post to Chat.
+        monkeypatch.delenv("LEAVE_SYNC_ALERTS_ENABLED", raising=False)
+        _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
+        mock_send.assert_not_called()
+
+    @patch("adviser_allocation.api.webhooks.send_chat_alert")
+    def test_sends_alert_when_enabled(self, mock_send, monkeypatch):
+        monkeypatch.setenv("LEAVE_SYNC_ALERTS_ENABLED", "true")
         _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
         mock_send.assert_called_once()
         payload = mock_send.call_args.args[0]
@@ -70,8 +78,9 @@ class TestAlertLeaveSyncProblem:
         assert "Leave sync failed" in payload["cards"][0]["header"]["title"]
 
     @patch("adviser_allocation.api.webhooks.send_chat_alert", side_effect=RuntimeError("down"))
-    def test_swallows_alert_errors(self, _mock_send):
-        # Alerting must never break the sync.
+    def test_swallows_alert_errors(self, _mock_send, monkeypatch):
+        # Alerting must never break the sync, even when enabled.
+        monkeypatch.setenv("LEAVE_SYNC_ALERTS_ENABLED", "true")
         _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
 
 


### PR DESCRIPTION
## Why
Leave-sync alerts were posting to the shared **Pivot Digital** Chat space (e.g. the "Leave sync produced no active/future leave" card from the post-#51 resync). This stops that.

## Change
- Leave-sync Chat alerts are now **off by default**, gated by `LEAVE_SYNC_ALERTS_ENABLED` (`true`/`1`/`yes` to enable).
- When off: the condition is still **logged at WARNING**, and the **stale-delete guard still blocks a wipe** — only the Chat post is suppressed (no loss of data protection).
- Applies to `_alert_leave_sync_problem` (main) and the stale-delete guard alert (repository).
- Re-enable later by setting the env var, or repoint `CHAT_WEBHOOK_URL` to a dedicated ops space.

## Tests
`tests/test_leave_sync_health.py`: alert suppressed by default; sends when enabled; never raises. 21 leave tests pass; lint clean.

## Note (manual step)
The card already posted to the Pivot Digital space can't be deleted via the incoming webhook (no message ID captured) — delete it manually in Chat.