### PR TITLE
Clean up EH leave diagnostics; re-enable leave-sync alerts

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -456,14 +456,14 @@ existing `CHAT_WEBHOOK_URL` webhook — no extra infra.
 | **Leave sync failed** | `/sync/leave_requests` (or the admin trigger) raised an exception | The sync errored out — token, network, or EH API failure. Check the stack trace in Cloud Run logs. |
 | **Leave sync skipped stale cleanup** | A run would have deleted > 50% of tracked active/future leave | An incomplete EH fetch was detected; the destructive delete was blocked. Investigate before the next sync. |
 
-### Enabling Chat alerts
+### Chat alerts toggle
 
-Leave-sync Chat alerts are **off by default** and gated by the env var
-`LEAVE_SYNC_ALERTS_ENABLED` (set to `true`/`1`/`yes` to post to the Chat space).
-When off, every alert condition is still **logged** (`WARNING`), and the
-stale-delete guard still blocks a wipe — only the Chat post is suppressed. Leave
-this off if the webhook points at a broad space; flip it on (or repoint
-`CHAT_WEBHOOK_URL` to a dedicated ops space) when you want active notifications.
+Leave-sync Chat alerts are **on by default**, gated by `LEAVE_SYNC_ALERTS_ENABLED`.
+Set it to a falsey value (`false`/`0`/`no`) to **suppress** posting while a known issue
+is being worked — every alert condition is still **logged** (`WARNING`) and the
+stale-delete guard still blocks a wipe; only the Chat post is silenced. Alerts post to
+`CHAT_WEBHOOK_URL`; repoint that secret to a dedicated ops space if leave alerts should
+not go to the shared space.
 
 ### Health signal in logs
 

--- a/src/adviser_allocation/db/repository.py
+++ b/src/adviser_allocation/db/repository.py
@@ -32,10 +32,10 @@ STALE_DELETE_MAX_RATIO = 0.5
 def _alert_stale_delete_guard(stale_count: int, tracked_count: int) -> None:
     """Send a Google Chat alert when the stale-leave delete guard trips.
 
-    Gated by LEAVE_SYNC_ALERTS_ENABLED (default off); the guard still blocks the
+    Gated by LEAVE_SYNC_ALERTS_ENABLED (default on); the guard still blocks the
     delete regardless, this only controls whether it posts to Chat.
     """
-    if os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "false").strip().lower() not in ("1", "true", "yes"):
+    if os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "true").strip().lower() not in ("1", "true", "yes"):
         logger.warning(
             "Stale-delete guard alert (Chat suppressed): would delete %d of %d tracked records",
             stale_count,

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -465,15 +465,18 @@ def leave_sync_result_is_healthy(fetched_count, kept_count, active_future_count)
 
 
 def _leave_sync_alerts_enabled() -> bool:
-    """Whether leave-sync Chat alerts should post. Off by default (set via env)."""
-    return os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+    """Whether leave-sync Chat alerts should post. On by default; set the env var to a
+    falsey value (false/0/no) to suppress posting (e.g. while a known issue is being worked).
+    """
+    return os.getenv("LEAVE_SYNC_ALERTS_ENABLED", "true").strip().lower() in ("1", "true", "yes")
 
 
 def _alert_leave_sync_problem(summary: str, details: list) -> None:
     """Send a Google Chat alert about a leave-sync problem (degraded result or failure).
 
-    Gated by LEAVE_SYNC_ALERTS_ENABLED (default off) so leave-sync alerts don't post
-    to the shared Chat space; the condition is always logged regardless.
+    Gated by LEAVE_SYNC_ALERTS_ENABLED (default on); the condition is always logged
+    regardless. Posts to CHAT_WEBHOOK_URL — repoint that secret to a dedicated ops space
+    if leave alerts should not go to the shared space.
     """
     if not _leave_sync_alerts_enabled():
         logger.warning("Leave-sync alert (Chat suppressed): %s | %s", summary, "; ".join(details))
@@ -486,64 +489,6 @@ def _alert_leave_sync_problem(summary: str, details: list) -> None:
         )
     except Exception as exc:
         logger.warning("Could not send leave-sync alert: %s", exc)
-
-
-def _log_eh_leave_diagnostics(headers) -> None:
-    """TEMP read-only probe: log why EH leave_requests returns empty.
-
-    Enumerates every organisation the token can see and, per org, the leave_requests
-    meta (status, total_items/total_pages, item count) plus a page_index 0-vs-1 check
-    and the employees meta as a working baseline. Counts/meta only — no token, no PII
-    values. Runs only when a sync fetched 0 items; remove once the root cause is found.
-    """
-
-    def _leave_meta(org_id, page_index):
-        r = requests.get(
-            f"{API_BASE}/api/v1/organisations/{org_id}/leave_requests",
-            headers=headers,
-            params={"item_per_page": 100, "page_index": page_index},
-            timeout=30,
-        )
-        meta = {"http_status": r.status_code, "page_index": page_index}
-        try:
-            payload = r.json().get("data", {})
-            meta.update(
-                {
-                    "item_count": len(payload.get("items", [])),
-                    "total_items": payload.get("total_items"),
-                    "total_pages": payload.get("total_pages"),
-                    "item_per_page_echo": payload.get("item_per_page"),
-                }
-            )
-        except Exception as exc:
-            meta["parse_error"] = str(exc)[:200]
-        return meta
-
-    try:
-        orgs_resp = requests.get(f"{API_BASE}/api/v1/organisations", headers=headers, timeout=30)
-        orgs = orgs_resp.json().get("data", {}).get("items", [])
-        chosen_org_id = orgs[0]["id"] if orgs else None
-        emps_resp = requests.get(
-            f"{API_BASE}/api/v1/organisations/{chosen_org_id}/employees",
-            headers=headers,
-            params={"item_per_page": 100},
-            timeout=30,
-        )
-        emp_payload = emps_resp.json().get("data", {})
-        diagnostics = {
-            "organisations_count": len(orgs),
-            "organisations": [{"id": o.get("id"), "name": o.get("name")} for o in orgs],
-            "chosen_org_id": chosen_org_id,
-            "leave_per_org": [
-                {"org_id": o.get("id"), "meta": _leave_meta(o.get("id"), 0)} for o in orgs
-            ],
-            "leave_chosen_page1": _leave_meta(chosen_org_id, 1) if chosen_org_id else None,
-            "employees_total_items": emp_payload.get("total_items"),
-            "employees_item_count": len(emp_payload.get("items", [])),
-        }
-        logger.info("EH leave diagnostics (empty fetch): %s", diagnostics)
-    except Exception:
-        logger.exception("EH leave diagnostics probe failed")
 
 
 @main_bp.route("/get/leave_requests")
@@ -625,10 +570,6 @@ def get_leave_requests():
         deleted,
         active_future_count,
     )
-
-    if fetched_count == 0:
-        # TEMP diagnostic: EH returned nothing — log orgs/per-org leave meta to find why.
-        _log_eh_leave_diagnostics(headers)
 
     if not leave_sync_result_is_healthy(fetched_count, len(leave_requests), active_future_count):
         _alert_leave_sync_problem(

--- a/tests/test_leave_sync_health.py
+++ b/tests/test_leave_sync_health.py
@@ -62,20 +62,21 @@ class TestLeaveSyncResultIsHealthy:
 
 class TestAlertLeaveSyncProblem:
     @patch("adviser_allocation.api.webhooks.send_chat_alert")
-    def test_suppressed_by_default(self, mock_send, monkeypatch):
-        # Default (flag unset) — leave-sync alerts must NOT post to Chat.
+    def test_sends_by_default(self, mock_send, monkeypatch):
+        # Default (flag unset) — leave-sync alerts post so genuine failures are noticed.
         monkeypatch.delenv("LEAVE_SYNC_ALERTS_ENABLED", raising=False)
-        _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
-        mock_send.assert_not_called()
-
-    @patch("adviser_allocation.api.webhooks.send_chat_alert")
-    def test_sends_alert_when_enabled(self, mock_send, monkeypatch):
-        monkeypatch.setenv("LEAVE_SYNC_ALERTS_ENABLED", "true")
         _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
         mock_send.assert_called_once()
         payload = mock_send.call_args.args[0]
         # build_chat_card_payload wraps the summary in the card title.
         assert "Leave sync failed" in payload["cards"][0]["header"]["title"]
+
+    @patch("adviser_allocation.api.webhooks.send_chat_alert")
+    def test_suppressed_when_disabled(self, mock_send, monkeypatch):
+        # Explicit opt-out (e.g. while a known issue is worked) suppresses the Chat post.
+        monkeypatch.setenv("LEAVE_SYNC_ALERTS_ENABLED", "false")
+        _alert_leave_sync_problem("Leave sync failed", ["Error: boom"])
+        mock_send.assert_not_called()
 
     @patch("adviser_allocation.api.webhooks.send_chat_alert", side_effect=RuntimeError("down"))
     def test_swallows_alert_errors(self, _mock_send, monkeypatch):


### PR DESCRIPTION
Follow-up cleanup now that leave sync is healthy (token reconnected to the correct EH org via re-auth → 140 leave rows, future leave present, Reece Dolan's 15–28 Jul 2026 leave restored).

## Changes
- **Remove** the temporary read-only `_log_eh_leave_diagnostics` probe (added in #54) and its call site. It pinpointed the wrong-org root cause; no longer needed.
- **Re-enable leave-sync Chat alerts**: flip `LEAVE_SYNC_ALERTS_ENABLED` default **off → on** (in `_alert_leave_sync_problem` and the repository stale-delete guard) so genuine future sync failures are noticed again. Set the env var to a falsey value to suppress while working a known issue.
  - ⚠️ Alerts post to `CHAT_WEBHOOK_URL` (currently the shared space). Repoint that secret to a dedicated ops space if leave alerts shouldn't go there.
- Update tests (sends by default; suppressed when explicitly disabled) and `docs/OPERATIONS.md`.

## Kept
- The 0-based pagination from #52 — **confirmed correct**: real data spans 5 pages (`page_index 0–4`, 100 each).

## Tests
21 leave tests pass; lint clean.