### PR TITLE
Fix/eh leave issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ A production Flask application that automatically allocates HubSpot deals to adv
 ### Run Locally
 
 ```bash
-pip install -r requirements.txt
-export FLASK_APP=main.py
-python main.py
+brew install uv 
+uv sync --extra dev
+uv pip install -r requirements.txt
+uv run python main.py
 # Visit http://localhost:8080
 ```
 

--- a/src/adviser_allocation/main.py
+++ b/src/adviser_allocation/main.py
@@ -390,34 +390,46 @@ def get_employees():
     """
     access_token = get_access_token()
     headers = {"Authorization": f"Bearer {access_token}"}
-    params = {
-        "item_per_page": 100,
-    }
 
     org_id = get_org_id(headers)
-    r_emps = requests.get(
-        f"{API_BASE}/api/v1/organisations/{org_id}/employees",
-        headers=headers,
-        params=params,
-        timeout=30,
-    )
-    if r_emps.status_code != 200:
-        raise RuntimeError(f"Refresh failed: {r_emps.status_code} {r_emps.text}")
-
-    employees = []
     cloudsql_db = get_cloudsql_db()
 
-    for emp in r_emps.json()["data"]["items"]:
-        item = {
-            "id": emp.get("id"),
-            "name": emp.get("full_name"),  # Using 'full_name' for 'name'
-            "company_email": emp.get("company_email"),
-            "account_email": emp.get("account_email"),
-        }
-        cloudsql_db.upsert_employee_dict(item)
-        employees.append(item)
+    employees = []
+    seen_employee_ids = set()
+    # page_index is 1-based (see the leave sync); paginate so the employee list is
+    # not silently capped at the first 100.
+    page = 1
+    total_pages = 1
+    last_status = 200
+    while page <= total_pages:
+        r_emps = requests.get(
+            f"{API_BASE}/api/v1/organisations/{org_id}/employees",
+            headers=headers,
+            params={"item_per_page": 100, "page_index": page},
+            timeout=30,
+        )
+        last_status = r_emps.status_code
+        if r_emps.status_code != 200:
+            raise RuntimeError(f"Refresh failed: {r_emps.status_code} {r_emps.text}")
 
-    return (employees, r_emps.status_code, {"Content-Type": "application/json"})
+        payload = r_emps.json()["data"]
+        total_pages = payload["total_pages"]
+        for emp in payload["items"]:
+            employee_id = emp.get("id")
+            if employee_id in seen_employee_ids:
+                continue
+            seen_employee_ids.add(employee_id)
+            item = {
+                "id": employee_id,
+                "name": emp.get("full_name"),  # Using 'full_name' for 'name'
+                "company_email": emp.get("company_email"),
+                "account_email": emp.get("account_email"),
+            }
+            cloudsql_db.upsert_employee_dict(item)
+            employees.append(item)
+        page += 1
+
+    return (employees, last_status, {"Content-Type": "application/json"})
 
 
 @main_bp.route("/get/employee_id")
@@ -512,11 +524,14 @@ def get_leave_requests():
 
     leave_requests = []
     fetched_count = 0
-    # Employment Hero's page_index is 0-based; starting at 1 skips the first page
-    # (where leave lives when there are few pages), which is why the sync drained.
-    page = 0
+    seen_leave_ids = set()
+    # Employment Hero's page_index is 1-based: requesting page_index=0 returns the
+    # same rows as page 1, so a 0-based loop both duplicates the first page AND never
+    # fetches the final page (page_index == total_pages), silently dropping a whole
+    # page of leave every sync. Iterate 1..total_pages and dedupe by id defensively.
+    page = 1
     total_pages = 1  # Seeded; replaced with the real count from the first response.
-    while page < total_pages:
+    while page <= total_pages:
         params = {
             "item_per_page": 100,
             "page_index": page,
@@ -542,10 +557,14 @@ def get_leave_requests():
             payload.get("total_count"),
         )
         for leave_request in items:
+            leave_request_id = leave_request.get("id")
+            if leave_request_id in seen_leave_ids:
+                continue
+            seen_leave_ids.add(leave_request_id)
             end_date_obj = datetime.fromisoformat(leave_request["end_date"]).date()
             if _should_track_leave(leave_request.get("status"), end_date_obj, now_date):
                 item = {
-                    "leave_request_id": leave_request.get("id"),
+                    "leave_request_id": leave_request_id,
                     "employee_id": leave_request.get("employee_id"),
                     "start_date": leave_request.get("start_date"),
                     "end_date": leave_request.get("end_date"),

--- a/tests/test_leave_sync_health.py
+++ b/tests/test_leave_sync_health.py
@@ -11,14 +11,103 @@ These lock in the prevention behaviour added after the silent leave-drain bug:
 from datetime import date
 from unittest.mock import MagicMock, patch
 
+from adviser_allocation import main
 from adviser_allocation.db.repository import AdviserAllocationDB
 from adviser_allocation.main import (
     _alert_leave_sync_problem,
     _should_track_leave,
+    get_leave_requests,
     leave_sync_result_is_healthy,
 )
 
 TODAY = date(2026, 6, 2)
+
+
+def _leave(leave_id, employee_id, end_date="2026-07-28", status="Approved"):
+    return {
+        "id": leave_id,
+        "employee_id": employee_id,
+        "start_date": "2026-07-15",
+        "end_date": end_date,
+        "status": status,
+    }
+
+
+def _make_eh_response(items, total_pages):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": {"items": items, "total_pages": total_pages, "total_count": None}
+    }
+    return resp
+
+
+class TestLeaveSyncPagination:
+    """Lock in that the EH leave fetch uses 1-based pagination and dedupes.
+
+    Employment Hero's ``page_index`` is 1-based: requesting ``page_index=0`` returns
+    the same rows as page 1. A 0-based loop therefore duplicated the first page and
+    never fetched the final page (``page_index == total_pages``), silently dropping a
+    whole page of leave — which is how an adviser's approved leave went missing.
+    """
+
+    def _run_sync(self, pages_by_index, total_pages):
+        """Run get_leave_requests against a fake EH that maps page_index -> items.
+
+        ``page_index=0`` deliberately returns page 1's rows (EH's real clamping
+        behaviour), so a regression to a 0-based loop drops the last page and fails.
+        """
+        requested_indexes = []
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            idx = params["page_index"]
+            requested_indexes.append(idx)
+            real_page = 1 if idx == 0 else idx
+            return _make_eh_response(pages_by_index.get(real_page, []), total_pages)
+
+        db = MagicMock()
+        db.delete_stale_future_leave.return_value = 0
+        db.count_active_future_leave.return_value = 99
+
+        with (
+            patch.object(main, "get_access_token", return_value="tok"),
+            patch.object(main, "get_org_id", return_value="org-1"),
+            patch.object(main, "get_cloudsql_db", return_value=db),
+            patch.object(main, "sydney_today", return_value=TODAY),
+            patch.object(main.requests, "get", side_effect=fake_get),
+        ):
+            leave_requests, _status, _headers = get_leave_requests()
+
+        upserted_ids = [
+            call.args[0]["leave_request_id"] for call in db.upsert_leave_request_dict.call_args_list
+        ]
+        return leave_requests, requested_indexes, upserted_ids
+
+    def test_fetches_final_page_including_its_leave(self):
+        # Leave that lives only on the last page must not be dropped.
+        pages = {
+            1: [_leave("p1", "emp-1")],
+            2: [_leave("p2", "emp-2")],
+            3: [_leave("p3", "emp-3")],
+            4: [_leave("p4", "emp-4")],
+            5: [_leave("ian-leave", "emp-ian")],
+        }
+        _kept, requested_indexes, upserted_ids = self._run_sync(pages, total_pages=5)
+
+        # Iterates page_index 1..5 — never 0, and includes the final page.
+        assert requested_indexes == [1, 2, 3, 4, 5]
+        assert "ian-leave" in upserted_ids
+
+    def test_dedupes_leave_seen_on_multiple_pages(self):
+        # A leave id appearing on more than one page is upserted once.
+        pages = {
+            1: [_leave("dup", "emp-1"), _leave("p1", "emp-1")],
+            2: [_leave("dup", "emp-1"), _leave("p2", "emp-2")],
+        }
+        kept, _requested_indexes, upserted_ids = self._run_sync(pages, total_pages=2)
+
+        assert upserted_ids.count("dup") == 1
+        assert sorted(lr["leave_request_id"] for lr in kept) == ["dup", "p1", "p2"]
 
 
 class TestShouldTrackLeave:


### PR DESCRIPTION
Root cause: Employment Hero's page_index is 1-based. Commit #52 changed the leave sync to 0-based, so page_index=0 returned a duplicate of page 1 and the loop (0..total_pages-1) never fetched the final page. The live probe proved it: total_pages=5 → 400 distinct records + 100 duplicates, with page 5 silently dropped. Ian Bell's approved leave was on that missing page, so the app treated him as fully available while on leave.

The fix (commit ba04e97 on branch fix/eh-leave-pagination-1-based):

Leave sync: iterate page_index 1..total_pages + dedupe by id — [main.py](vscode-webview://0horsj5nn7leeoa8eon6obatkqhr03ierc3krcgkip3musu90sb8/src/adviser_allocation/main.py)
Employee sync: added the same 1-based pagination (it was silently capped at the first 100 employees) + dedupe
Regression tests locking in 1-based traversal and dedup — [test_leave_sync_health.py](vscode-webview://0horsj5nn7leeoa8eon6obatkqhr03ierc3krcgkip3musu90sb8/tests/test_leave_sync_health.py)