### PR TITLE
fix(box): tag Primary/Spouse from the deal's authoritative Client labels

### DIFF
--- a/src/adviser_allocation/api/box_routes.py
+++ b/src/adviser_allocation/api/box_routes.py
@@ -108,6 +108,76 @@ def _resolve_deal_id(payload: dict) -> Optional[str]:
     )
 
 
+def _contact_by_label(contacts: Optional[List[dict]], label: str) -> Optional[dict]:
+    """First deal contact whose HubSpot association label matches (case-insensitive)."""
+    target = label.strip().lower()
+    for contact in contacts or []:
+        for assoc in contact.get("association_types", []):
+            if (assoc.get("label") or "").strip().lower() == target:
+                return contact
+    return None
+
+
+def _authoritative_household_from_deal(
+    deal_id: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve (primary_contact_id, spouse_contact_id) from the deal's HubSpot
+    association LABELS, which are the source of truth: "Client" (assoc type 98/99)
+    is the primary, "Client's Spouse" (100/101) the spouse.
+
+    Returns ``(None, None)`` when the deal id, its contacts, or the "Client" label
+    can't be resolved — callers then leave the existing metadata untouched rather
+    than guess. ``primary == spouse`` collapses the spouse to ``None`` so one person
+    is never tagged as both.
+    """
+    deal_id = (deal_id or "").strip()
+    if not deal_id:
+        return None, None
+    try:
+        contacts = box_service.get_hubspot_deal_contacts(deal_id)
+    except Exception as exc:  # noqa: BLE001 - never fail tagging on a lookup error
+        logger.warning("Authoritative household lookup failed for deal %s: %s", deal_id, exc)
+        return None, None
+
+    client = _contact_by_label(contacts, "Client")
+    spouse = _contact_by_label(contacts, "Client's Spouse")
+    primary_id = str(client.get("id")).strip() if client and client.get("id") else None
+    spouse_id = str(spouse.get("id")).strip() if spouse and spouse.get("id") else None
+    if primary_id and spouse_id and primary_id == spouse_id:
+        spouse_id = None
+    return primary_id, spouse_id
+
+
+def _apply_authoritative_household(metadata: dict, deal_id: Optional[str]) -> dict:
+    """Override the Primary/Spouse metadata with the deal's authoritative Client /
+    Client's-Spouse before tagging Box. Conservative: only sets what we can resolve,
+    and never clears an existing spouse when no "Client's Spouse" label is found."""
+    primary_id, spouse_id = _authoritative_household_from_deal(deal_id)
+    if primary_id:
+        current = str(metadata.get("primary_contact_id") or "").strip()
+        if current and current != primary_id:
+            logger.info(
+                "Authoritative override: primary_contact_id %s -> %s (deal %s)",
+                current,
+                primary_id,
+                deal_id,
+            )
+        metadata["primary_contact_id"] = primary_id
+        metadata["primary_contact_link"] = _hubspot_contact_url(primary_id) or primary_id
+    if spouse_id:
+        current = str(metadata.get("hs_spouse_id") or "").strip()
+        if current and current != spouse_id:
+            logger.info(
+                "Authoritative override: hs_spouse_id %s -> %s (deal %s)",
+                current,
+                spouse_id,
+                deal_id,
+            )
+        metadata["hs_spouse_id"] = spouse_id
+        metadata["spouse_contact_link"] = _hubspot_contact_url(spouse_id) or spouse_id
+    return metadata
+
+
 def _stable_bucket(value: str, slots: int) -> int:
     normalized = (value or "").strip()
     if not normalized or slots <= 1:
@@ -737,19 +807,10 @@ def _load_contact_details_with_deals(email: str) -> Tuple[Optional[dict], List[d
         try:
             deal_contacts = box_service.get_hubspot_deal_contacts(deal_id)
 
-            def _contact_by_label(label: str, contacts=deal_contacts) -> Optional[dict]:
-                target = label.strip().lower()
-                for contact_entry in contacts:
-                    for assoc in contact_entry.get("association_types", []):
-                        assoc_label = (assoc.get("label") or "").strip().lower()
-                        if assoc_label == target:
-                            return contact_entry
-                return None
-
-            primary_entry = _contact_by_label("Client") or (
+            primary_entry = _contact_by_label(deal_contacts, "Client") or (
                 deal_contacts[0] if deal_contacts else None
             )
-            spouse_entry = _contact_by_label("Client's Spouse")
+            spouse_entry = _contact_by_label(deal_contacts, "Client's Spouse")
 
             for idx, contact_entry in enumerate(deal_contacts):
                 contact_props = contact_entry.get("properties") or {}
@@ -1435,31 +1496,27 @@ def _fetch_deal_metadata(deal_id: str) -> Optional[dict]:
         props = resp.json().get("properties", {})
         contacts = box_service.get_hubspot_deal_contacts(deal_id)
 
-        def _contact_by_label(label: str) -> Optional[dict]:
-            target = label.strip().lower()
-            for contact in contacts:
-                for assoc in contact.get("association_types", []):
-                    assoc_label = (assoc.get("label") or "").strip().lower()
-                    if assoc_label == target:
-                        return contact
-            return None
-
         associated_contact_ids: list[str] = [
             str(contact.get("id")) for contact in contacts if contact.get("id")
         ]
 
-        primary_contact = _contact_by_label("Client") or (contacts[0] if contacts else None)
-        spouse_contact = _contact_by_label("Client's Spouse")
+        primary_contact = _contact_by_label(contacts, "Client") or (
+            contacts[0] if contacts else None
+        )
+        spouse_contact = _contact_by_label(contacts, "Client's Spouse")
 
+        # Association labels are authoritative; the hs_contact_id / hs_spouse_id deal
+        # properties are set upstream and can be wrong (the Primary/Spouse swap), so
+        # prefer the "Client" / "Client's Spouse" labels over the properties.
         primary_contact_id = (
-            props.get("hs_contact_id")
-            or (primary_contact.get("id") if primary_contact else None)
+            (primary_contact.get("id") if primary_contact else None)
+            or props.get("hs_contact_id")
             or (associated_contact_ids[0] if associated_contact_ids else None)
         )
         primary_contact_link = _hubspot_contact_url(primary_contact_id)
 
-        spouse_id = props.get("hs_spouse_id") or (
-            spouse_contact.get("id") if spouse_contact else None
+        spouse_id = (spouse_contact.get("id") if spouse_contact else None) or props.get(
+            "hs_spouse_id"
         )
         spouse_link = _hubspot_contact_url(spouse_id)
 
@@ -1884,6 +1941,7 @@ def box_folder_apply_metadata():
     )
     metadata = _merge_metadata(metadata_payload, metadata_override) or {}
     metadata = _ensure_required_metadata_fields(metadata, None)
+    metadata = _apply_authoritative_household(metadata, deal_id)
 
     missing_metadata = _missing_metadata_fields(metadata)
     if missing_metadata:
@@ -1983,6 +2041,9 @@ def box_folder_apply_metadata_auto():
             metadata = _merge_metadata(metadata, fetched_metadata) or fetched_metadata
             metadata_source = "payload+hubspot" if metadata_source == "payload" else "hubspot"
         missing_metadata = _missing_metadata_fields(metadata)
+
+    metadata = _apply_authoritative_household(metadata, deal_id)
+    missing_metadata = _missing_metadata_fields(metadata)
 
     if missing_metadata:
         logger.error(

--- a/src/adviser_allocation/api/box_routes.py
+++ b/src/adviser_allocation/api/box_routes.py
@@ -9,7 +9,16 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
 import requests
-from flask import Blueprint, jsonify, redirect, render_template, request, session
+from flask import (
+    Blueprint,
+    g,
+    has_request_context,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+)
 
 from adviser_allocation.api.webhooks import build_chat_card_payload, send_chat_alert
 from adviser_allocation.services import box_folder_service as box_service
@@ -118,6 +127,24 @@ def _contact_by_label(contacts: Optional[List[dict]], label: str) -> Optional[di
     return None
 
 
+def _deal_contacts(deal_id: str) -> List[dict]:
+    """``get_hubspot_deal_contacts`` memoised per Flask request, so the auto endpoint
+    (which resolves the deal in both ``_fetch_deal_metadata`` and the authoritative
+    override) makes one HubSpot round-trip instead of two."""
+    deal_id = str(deal_id or "").strip()
+    if not deal_id:
+        return []
+    if has_request_context():
+        cache = getattr(g, "_deal_contacts_cache", None)
+        if cache is None:
+            cache = {}
+            g._deal_contacts_cache = cache
+        if deal_id not in cache:
+            cache[deal_id] = box_service.get_hubspot_deal_contacts(deal_id)
+        return cache[deal_id]
+    return box_service.get_hubspot_deal_contacts(deal_id)
+
+
 def _authoritative_household_from_deal(
     deal_id: Optional[str],
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -134,9 +161,20 @@ def _authoritative_household_from_deal(
     if not deal_id:
         return None, None
     try:
-        contacts = box_service.get_hubspot_deal_contacts(deal_id)
+        contacts = _deal_contacts(deal_id)
     except Exception as exc:  # noqa: BLE001 - never fail tagging on a lookup error
         logger.warning("Authoritative household lookup failed for deal %s: %s", deal_id, exc)
+        return None, None
+
+    # Distinguish "no Client among labelled contacts" (genuine) from "association data
+    # unavailable" (HubSpot v4 read failed -> contacts carry no labels). The latter would
+    # silently fall back to the possibly-swapped payload, so make it observable.
+    if contacts and not any(c.get("association_types") for c in contacts):
+        logger.warning(
+            "Deal %s contacts carry no association labels (HubSpot association read likely "
+            "failed); skipping authoritative primary/spouse override.",
+            deal_id,
+        )
         return None, None
 
     client = _contact_by_label(contacts, "Client")
@@ -175,6 +213,18 @@ def _apply_authoritative_household(metadata: dict, deal_id: Optional[str]) -> di
             )
         metadata["hs_spouse_id"] = spouse_id
         metadata["spouse_contact_link"] = _hubspot_contact_url(spouse_id) or spouse_id
+    elif primary_id and str(metadata.get("hs_spouse_id") or "").strip() == primary_id:
+        # No authoritative spouse resolved, but the surviving spouse equals the new
+        # primary (a swap where the spouse field carried the Client). Clear it rather
+        # than tag one person as both; "" makes apply_metadata_template remove the field
+        # (spouse fields aren't in REQUIRED_METADATA_TEMPLATE_FIELDS, so this is safe).
+        logger.info(
+            "Authoritative override: clearing hs_spouse_id (== primary %s) on deal %s",
+            primary_id,
+            deal_id,
+        )
+        metadata["hs_spouse_id"] = ""
+        metadata["spouse_contact_link"] = ""
     return metadata
 
 
@@ -1494,7 +1544,7 @@ def _fetch_deal_metadata(deal_id: str) -> Optional[dict]:
             return None
         resp.raise_for_status()
         props = resp.json().get("properties", {})
-        contacts = box_service.get_hubspot_deal_contacts(deal_id)
+        contacts = _deal_contacts(deal_id)
 
         associated_contact_ids: list[str] = [
             str(contact.get("id")) for contact in contacts if contact.get("id")

--- a/tests/test_box_routes.py
+++ b/tests/test_box_routes.py
@@ -6,9 +6,18 @@ unreliable hs_contact_id/hs_spouse_id deal properties (which an upstream HubSpot
 workflow can set wrong, producing the Primary/Spouse swap).
 """
 
+import hashlib
+import json
 from unittest.mock import patch
 
 from adviser_allocation.api import box_routes
+from adviser_allocation.main import app as flask_app
+
+TEST_HUBSPOT_SECRET = "test-hubspot-client-secret"  # pragma: allowlist secret
+
+
+def _hubspot_sig(method, url, body=""):
+    return hashlib.sha256((TEST_HUBSPOT_SECRET + method + url + body).encode("utf-8")).hexdigest()
 
 
 def _contacts(*pairs):
@@ -109,3 +118,70 @@ def test_apply_no_spouse_label_never_clears_existing_spouse(mock_get, _url):
     out = box_routes._apply_authoritative_household(dict(metadata), "D1")
     assert out["primary_contact_id"] == "111"
     assert out["hs_spouse_id"] == "888"  # conservative: left untouched
+
+
+@patch.object(box_routes, "_hubspot_contact_url", side_effect=lambda cid: f"url/{cid}")
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_apply_clears_spouse_that_collapses_to_primary(mock_get, _url):
+    """Swap with only a 'Client' label: payload spouse == the real Client. After
+    primary is corrected, the surviving spouse equals the primary -> clear it (C3)."""
+    mock_get.return_value = _contacts(("111", "Client"))  # no spouse label
+    metadata = {"primary_contact_id": "222", "hs_spouse_id": "111"}  # spouse carried the Client
+    out = box_routes._apply_authoritative_household(metadata, "D1")
+    assert out["primary_contact_id"] == "111"
+    assert out["hs_spouse_id"] == ""  # cleared (removed from Box), not left == primary
+    assert out["spouse_contact_link"] == ""
+
+
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_association_data_unavailable_skips_override(mock_get):
+    """If contacts carry no association labels (HubSpot v4 read failed), don't
+    silently trust the payload — return (None, None) so the override is skipped."""
+    mock_get.return_value = [{"id": "111", "properties": {}, "association_types": []}]
+    assert box_routes._authoritative_household_from_deal("D1") == (None, None)
+
+
+# --- endpoint-level wiring -----------------------------------------------------
+
+
+@patch.object(box_routes, "_update_hubspot_contacts_with_folder_url")
+@patch.object(box_routes, "_update_hubspot_deal_properties", return_value=True)
+@patch.object(box_routes, "_record_metadata_snapshot_tag")
+@patch.object(box_routes, "ensure_box_service")
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+@patch("adviser_allocation.utils.auth.get_secret")
+def test_manual_tag_endpoint_applies_authoritative_primary(
+    mock_secret, mock_contacts, mock_ensure, *_mocks
+):
+    """End-to-end: a payload that names the SPOUSE as hs_contact_id still results in
+    the deal's Client being written to Box as primary_contact_id."""
+    mock_secret.return_value = TEST_HUBSPOT_SECRET
+    mock_contacts.return_value = _contacts(("111", "Client"), ("222", "Client's Spouse"))
+    service = mock_ensure.return_value
+
+    payload = {
+        "folder_id": "987654",
+        "hs_deal_record_id": "D1",
+        "hs_contact_id": "222",  # swapped: payload says the spouse is the primary
+        "hs_contact_firstname": "Stuart",
+        "hs_contact_lastname": "Kent",
+        "hs_contact_email": "stuart@example.com",
+        "deal_salutation": "Jessica & Stuart",
+        "household_type": "Couple",
+    }
+    body = json.dumps(payload)
+    url = "http://localhost/box/folder/tag"
+    flask_app.config["TESTING"] = True
+    client = flask_app.test_client()
+    resp = client.post(
+        "/box/folder/tag",
+        data=body,
+        content_type="application/json",
+        headers={"X-HubSpot-Signature": _hubspot_sig("POST", url, body)},
+    )
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    service.apply_metadata_template.assert_called_once()
+    _folder_id, applied = service.apply_metadata_template.call_args[0]
+    assert applied["primary_contact_id"] == "111"  # the Client, not the payload's 222
+    assert applied["hs_spouse_id"] == "222"  # the Client's Spouse

--- a/tests/test_box_routes.py
+++ b/tests/test_box_routes.py
@@ -1,0 +1,111 @@
+"""Tests for the authoritative Primary/Spouse resolution in the Box tagger.
+
+The tagger must source the Box folder's primary_contact_id from the deal's "Client"
+association label and the spouse (hs_spouse_id) from "Client's Spouse" — NOT from the
+unreliable hs_contact_id/hs_spouse_id deal properties (which an upstream HubSpot
+workflow can set wrong, producing the Primary/Spouse swap).
+"""
+
+from unittest.mock import patch
+
+from adviser_allocation.api import box_routes
+
+
+def _contacts(*pairs):
+    """Build deal-contact dicts shaped like get_hubspot_deal_contacts() output."""
+    return [
+        {"id": cid, "properties": {}, "association_types": [{"label": label}]}
+        for cid, label in pairs
+    ]
+
+
+# --- _contact_by_label ---------------------------------------------------------
+
+
+def test_contact_by_label_is_case_insensitive():
+    contacts = _contacts(("1", "Client"), ("2", "Client's Spouse"))
+    assert box_routes._contact_by_label(contacts, "client")["id"] == "1"
+    assert box_routes._contact_by_label(contacts, "CLIENT'S SPOUSE")["id"] == "2"
+
+
+def test_contact_by_label_no_match_returns_none():
+    contacts = _contacts(("1", "Deal Referred By"))
+    assert box_routes._contact_by_label(contacts, "Client") is None
+    assert box_routes._contact_by_label(None, "Client") is None
+
+
+# --- _authoritative_household_from_deal ----------------------------------------
+
+
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_authoritative_resolves_client_and_spouse(mock_get):
+    mock_get.return_value = _contacts(("111", "Client"), ("222", "Client's Spouse"))
+    assert box_routes._authoritative_household_from_deal("D1") == ("111", "222")
+
+
+def test_authoritative_no_deal_id_returns_none():
+    assert box_routes._authoritative_household_from_deal("") == (None, None)
+    assert box_routes._authoritative_household_from_deal(None) == (None, None)
+
+
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_authoritative_lookup_error_is_swallowed(mock_get):
+    mock_get.side_effect = RuntimeError("hubspot down")
+    assert box_routes._authoritative_household_from_deal("D1") == (None, None)
+
+
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_authoritative_no_client_label_does_not_invent_primary(mock_get):
+    mock_get.return_value = _contacts(("222", "Client's Spouse"))
+    primary, spouse = box_routes._authoritative_household_from_deal("D1")
+    assert primary is None and spouse == "222"
+
+
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_authoritative_self_spouse_is_dropped(mock_get):
+    # Same contact carries both labels -> never tag one person as both.
+    mock_get.return_value = [
+        {
+            "id": "111",
+            "properties": {},
+            "association_types": [{"label": "Client"}, {"label": "Client's Spouse"}],
+        }
+    ]
+    assert box_routes._authoritative_household_from_deal("D1") == ("111", None)
+
+
+# --- _apply_authoritative_household (the override) ------------------------------
+
+
+@patch.object(box_routes, "_hubspot_contact_url", side_effect=lambda cid: f"url/{cid}")
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_apply_corrects_swapped_primary_and_spouse(mock_get, _url):
+    """Payload had Primary = the spouse and spouse = the Client (the swap); the
+    authoritative Client/Spouse labels correct both."""
+    mock_get.return_value = _contacts(("111", "Client"), ("222", "Client's Spouse"))
+    metadata = {"primary_contact_id": "222", "hs_spouse_id": "111"}  # swapped
+    out = box_routes._apply_authoritative_household(metadata, "D1")
+    assert out["primary_contact_id"] == "111"
+    assert out["primary_contact_link"] == "url/111"
+    assert out["hs_spouse_id"] == "222"
+    assert out["spouse_contact_link"] == "url/222"
+
+
+@patch.object(box_routes, "_hubspot_contact_url", side_effect=lambda cid: f"url/{cid}")
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_apply_no_client_label_leaves_payload_untouched(mock_get, _url):
+    mock_get.return_value = _contacts(("999", "Deal Referred By"))
+    metadata = {"primary_contact_id": "555", "hs_spouse_id": "556"}
+    out = box_routes._apply_authoritative_household(dict(metadata), "D1")
+    assert out["primary_contact_id"] == "555"  # not overridden
+    assert out["hs_spouse_id"] == "556"  # not cleared
+
+
+@patch.object(box_routes, "_hubspot_contact_url", side_effect=lambda cid: f"url/{cid}")
+@patch.object(box_routes.box_service, "get_hubspot_deal_contacts")
+def test_apply_no_spouse_label_never_clears_existing_spouse(mock_get, _url):
+    mock_get.return_value = _contacts(("111", "Client"))  # no spouse label
+    metadata = {"primary_contact_id": "111", "hs_spouse_id": "888"}
+    out = box_routes._apply_authoritative_household(dict(metadata), "D1")
+    assert out["primary_contact_id"] == "111"
+    assert out["hs_spouse_id"] == "888"  # conservative: left untouched


### PR DESCRIPTION
## Why

The Box folder tagger (`/box/folder/tag` + `/box/folder/tag/auto`, called by a HubSpot workflow) sourced the **Primary** from the deal/payload field `hs_contact_id` and the **Spouse** from `hs_spouse_id`, treating HubSpot's deal-association **labels** ("Client" = assoc 98/99, "Client's Spouse" = 100/101) only as a fallback. `hs_contact_id` is set upstream by a HubSpot workflow (we only read it), so when it carries the spouse, the tagger wrote the **spouse as Primary** and the real **Client as Spouse**. This swap left ~80 client folders mis-tagged and a client's folder invisible in elle (it's what the gcs-data-lake `box-metadata-audit` job had to repair).

## What

Make the association labels **authoritative**:
- `_authoritative_household_from_deal(deal_id)` → Primary ← "Client", Spouse ← "Client's Spouse" (via `get_hubspot_deal_contacts`). Returns `(None, None)` when the deal/contacts/Client can't be resolved (callers then leave metadata untouched rather than guess); collapses self-spouse.
- `_apply_authoritative_household()` overrides `primary_contact_id`/`primary_contact_link` + `hs_spouse_id`/`spouse_contact_link` in **both** apply endpoints before `apply_metadata_template`; logs when it corrects a disagreeing payload value. Only those 4 keys are written to Box (the only contact keys in `BOX_METADATA_FIELD_MAP`).
- `_fetch_deal_metadata` now prefers the labels over the unreliable `hs_contact_id`/`hs_spouse_id` deal properties.
- Unified the duplicated `_contact_by_label` closures into one module-level helper.

**Conservative / safe:** never clears a *valid different* spouse; only clears the spouse when it collapses to the primary (a swap). Stops the mis-tagging at the source — the repair job becomes a safety net.

## Hardening (from an adversarial review)
- **Per-request memoisation** of `get_hubspot_deal_contacts` (`_deal_contacts` via `flask.g`) so the auto path makes one HubSpot round-trip, not two.
- **Observability**: if deal contacts carry no association labels (HubSpot v4 read failed), log a warning and skip the override rather than silently trust the payload.
- **Spouse-collapse clear** (C3 above).

## Tests
`tests/test_box_routes.py` — 13 tests: label match (case-insensitive), authoritative resolution, no-deal/lookup-error/no-Client/self-spouse, swap correction, conservative no-clear, spouse-collapse clear, association-data-unavailable skip, and an **endpoint-level** POST `/box/folder/tag` asserting the Client (not the payload's spouse) is written as primary. `ruff` clean.

## Out of scope
The deal's `hs_contact_id`/`hs_spouse_id` **properties** are set upstream by a HubSpot workflow and remain wrong (this just stops *propagating* the error to Box) — a separate HubSpot-side cleanup.

## Rollback
Code-only (no schema/data). Revert; the tagger reverts on the next deploy.
